### PR TITLE
Fixed to correctly diagnose expressions with NPC

### DIFF
--- a/src/c.h
+++ b/src/c.h
@@ -445,6 +445,7 @@ extern Tree cnsttree(Type, ...);
 extern Tree consttree(int, Type);
 extern Tree eqtree(int, Tree, Tree);
 extern int iscallb(Tree);
+extern int isnullptr(Tree);
 extern Tree shtree(int, Tree, Tree);
 extern void typeerror(int, Tree, Tree);
 

--- a/src/enode.c
+++ b/src/enode.c
@@ -6,7 +6,6 @@ static Tree addtree(int, Tree, Tree);
 static Tree andtree(int, Tree, Tree);
 static Tree cmptree(int, Tree, Tree);
 static int compatible(Type, Type);
-static int isnullptr(Tree e);
 static Tree multree(int, Tree, Tree);
 static Tree subtree(int, Tree, Tree);
 #define isvoidptr(ty) \
@@ -226,7 +225,7 @@ static int compatible(Type ty1, Type ty2) {
 	    && isptr(ty2) && !isfunc(ty2->type)
 	    && eqtype(unqual(ty1->type), unqual(ty2->type), 0);
 }
-static int isnullptr(Tree e) {
+int isnullptr(Tree e) {
 	Type ty = unqual(e->type);
 
 	return generic(e->op) == CNST

--- a/src/expr.c
+++ b/src/expr.c
@@ -621,7 +621,7 @@ Tree cast(Tree p, Type type) {
 			p = simplify(CVP, dst, p, NULL);
 		else {
 			if (isfunc(src->type) && !isfunc(dst->type)
-			|| !isfunc(src->type) &&  isfunc(dst->type))
+			|| !isnullptr(p) && !isfunc(src->type) && isfunc(dst->type))
 				warning("conversion from `%t' to `%t' is compiler dependent\n", p->type, type);
 
 			if (src->size != dst->size)


### PR DESCRIPTION
This commit lets lcc correctly diagnose the following code:

```
typedef void (*fp_t)(void);

fp_t func(fp_t param)
{
    return (void *)0;          /* line A */
}

int main(void)
{
    fp_t t = (void *)0;       /* line B */
    t = (void *)0;            /* line C */
    return func((void *)0)    /* line D */
               == (void *)0;
}
```

According to the Standard, the commented lines above should not be considered non-portable while lcc says:

```
5: warning: conversion from `pointer to void' to `pointer to void function(void)' is compiler dependent
10: warning: conversion from `pointer to void' to `pointer to void function(void)' is compiler dependent
11: warning: conversion from `pointer to void' to `pointer to void function(void)' is compiler dependent
12: warning: conversion from `pointer to void' to `pointer to void function(void)' is compiler dependent
```

EDIT: an example regarding a conditional expression and NPC has been removed because it was wrong; constant expressions can be or have conditional expressions. No problem with them in lcc.
