### PR TITLE
Fix memmove()

### DIFF
--- a/cpp/unix.c
+++ b/cpp/unix.c
@@ -98,7 +98,7 @@ memmove(void *dp, const void *sp, size_t n)
 	unsigned char *cdp, *csp;
 
 	if (n==0)
-		return 0;
+		return dp;
 	cdp = dp;
 	csp = (unsigned char *)sp;
 	if (cdp < csp) {
@@ -112,5 +112,5 @@ memmove(void *dp, const void *sp, size_t n)
 			*--cdp = *--csp;
 		} while (--n);
 	}
-	return 0;
+	return dp;
 }


### PR DESCRIPTION
[The lcc source] overrides the libc memmove() with its own implementation,
but that implementation fails to follow the specification. In particular,
it returns NULL rather than memmove()'s first parameter.

GCC now optimizes based on this aspect of the specification, so things go
wrong at runtime.

[Text & patch from http://gcc.gnu.org/bugzilla/show_bug.cgi?id=56881#c8]