### PR TITLE
Fixed assertion failure on assignment to unsigned bitfields

### DIFF
--- a/src/enode.c
+++ b/src/enode.c
@@ -320,7 +320,7 @@ Tree asgntree(int op, Tree l, Tree r) {
 		long n = 8*l->u.field->type->size - fieldsize(l->u.field);
 		if (n > 0 && isunsigned(l->u.field->type))
 			r = bittree(BAND, r,
-				cnsttree(r->type, (unsigned long)fieldmask(l->u.field)));
+				cnsttree(unsignedtype, (unsigned long)fieldmask(l->u.field)));
 		else if (n > 0) {
 			if (r->op == CNST+I) {
 				n = r->u.v.i;


### PR DESCRIPTION
Trying to assign a struct to a unsigned bitfield triggers an assertion failure. For example, given this:

    void f(void)
    {
        struct { int foo:3; } x;
        struct { unsigned foo:3; } y;

        x.foo = x;
        y.foo = y;    /* line A */
    }

lcc terminates saying:

    6: operands of = have illegal types `int' and `struct defined at 3'
    6: operands of << have illegal types `struct defined at 3' and `int'
    7: operands of = have illegal types `unsigned int' and `struct defined at 4'
    rcc: src/enode.c:192: cnsttree: Assertion `0' failed.
    Aborted

This is because, unlike an assignment to signed bitfield, an assignment to unsigned one assumes that the type of its right operand has a type from which `cnsttree()` can generate a constant.
