### PR TITLE
Fixed the result of unary + to generate rvalue

### DIFF
--- a/src/expr.c
+++ b/src/expr.c
@@ -157,9 +157,11 @@ static Tree unary(void) {
 						  	p->u.sym->addressed = 1;
  break;
 	case '+':    t = gettok(); p = unary(); p = pointer(p);
-						  if (isarith(p->type))
-						  	p = cast(p, promote(p->type));
-						  else
+						  if (isarith(p->type)) {
+							p = cast(p, promote(p->type));
+							if (generic(p->op) == INDIR)
+								p = tree(RIGHT, p->type, NULL, p);
+						  } else
 						  	typeerror(ADD, p, NULL);  break;
 	case '-':    t = gettok(); p = unary(); p = pointer(p);
 						  if (isarith(p->type)) {


### PR DESCRIPTION
Given an lvalue as an operand of the unary `+`, lcc generates an lvalue even if it should not. Thus,

```
void foo(void)
{
    int x, *p;
    p = &+x;
    +x = 0;
}
```

it silently accepts this incorrect code.

A simple fix for this issue is to make a `RIGHT` tree when the result of `+` is an lvalue, as done in constructing cast trees.
