### PR TITLE
fix x86 CALLF

### DIFF
--- a/src/x86.md
+++ b/src/x86.md
@@ -576,10 +576,13 @@ reg:  CALLI4(addrj)  "call %0\nadd esp,%a\n"
 reg:  CALLU4(addrj)  "call %0\nadd esp,%a\n"
 reg:  CALLP4(addrj)  "call %0\nadd esp,%a\n"
 stmt: CALLV(addrj)   "call %0\nadd esp,%a\n"
-reg: CALLF4(addrj)  "call %0\nadd esp,%a\n"
-reg: CALLF8(addrj)  "call %0\nadd esp,%a\n"
+
 stmt: CALLF4(addrj)  "call %0\nadd esp,%a\nfstp\n"
 stmt: CALLF8(addrj)  "call %0\nadd esp,%a\nfstp\n"
+
+reg: CALLF4(addrj)  "call %0\nadd esp,%a\n"
+reg: CALLF8(addrj)  "call %0\nadd esp,%a\n"
+
 
 stmt: RETI4(reg)  "# ret\n"
 stmt: RETU4(reg)  "# ret\n"

--- a/src/x86linux.md
+++ b/src/x86linux.md
@@ -664,17 +664,18 @@ stmt: CALLV(addrj)   "call %0\naddl $%a-4,%%esp\n"      hasargs(a) + !isstruct(f
 stmt: CALLV(addrj)   "call %0\naddl $%a,%%esp\n"        hasargs(a) +  isstruct(freturn(a->syms[1]->type))
 stmt: CALLV(addrj)   "call %0\n"                        1
 
-freg: CALLF4(addrj)  "call %0\naddl $%a,%%esp\n"        hasargs(a)
-freg: CALLF4(addrj)  "call %0\n"                        1
-
 stmt: CALLF4(addrj)  "call %0\naddl $%a,%%esp\nfstp %%st(0)\n"  hasargs(a)
 stmt: CALLF4(addrj)  "call %0\nfstp %%st(0)\n"                  1
+
+stmt: CALLF8(addrj)  "call %0\naddl $%a,%%esp\nfstp %%st(0)\n"  hasargs(a)
+stmt: CALLF8(addrj)  "call %0\nfstp %%st(0)\n"                  1
+
+freg: CALLF4(addrj)  "call %0\naddl $%a,%%esp\n"        hasargs(a)
+freg: CALLF4(addrj)  "call %0\n"                        1
 
 freg: CALLF8(addrj)  "call %0\naddl $%a,%%esp\n"        hasargs(a)
 freg: CALLF8(addrj)  "call %0\n"                        1
 
-stmt: CALLF8(addrj)  "call %0\naddl $%a,%%esp\nfstp %%st(0)\n"  hasargs(a)
-stmt: CALLF8(addrj)  "call %0\nfstp %%st(0)\n"                  1
 
 stmt: RETI4(reg)  "# ret\n"
 stmt: RETU4(reg)  "# ret\n"


### PR DESCRIPTION
Reported in `comp.compilers.lcc` on 3/3/2013. (news:cff50e0c-3bb4-4456-ba98-1641eeacd772@googlegroups.com)


> On compiling expression statements like
>
>   `foo(); foo(); foo();`
>
> where foo is declared as
>
>   `double foo(void);`
>
> the compiler generates
>
>   `call foo`
>   `call foo`
>   `call foo`
>
> rather than
>
>   `call foo`
>   `fstpl %st(0)`
>   `call foo`
>   `fstpl %st(0)`
>   `call foo`
>   `fstpl %st(0)`

The underlying issue is that the `reg: CALLF`  (which doesn't clean up the x87 stack) is preferred over the `stmt: CALLF` (which does clean up the stack).  Re-ordering the `stmt: CALLF` first fixes the problem.