### PR TITLE
lburg - fix strchr when buffer doesn't have an eol.

### DIFF
--- a/lburg/gram.c
+++ b/lburg/gram.c
@@ -316,7 +316,7 @@ int yylex(void) {
 		bp += strspn(bp, " \t\f");
 		p = strchr(bp, '\n');
 		if (p == NULL)
-			p = strchr(bp, '\n');
+			p = strchr(bp, '\0');
 		while (p > bp && isspace(p[-1]))
 			p--;
 		yylval.string = alloc(p - bp + 1);

--- a/lburg/gram.y
+++ b/lburg/gram.y
@@ -117,7 +117,7 @@ int yylex(void) {
 		bp += strspn(bp, " \t\f");
 		p = strchr(bp, '\n');
 		if (p == NULL)
-			p = strchr(bp, '\n');
+			p = strchr(bp, '\0');
 		while (p > bp && isspace(p[-1]))
 			p--;
 		yylval.string = alloc(p - bp + 1);


### PR DESCRIPTION
if `strchr(bp, '\n')` didn't find anything the first time, it won't find anything the second time, either.
Change to`'\0'` to find the end-of-line. It's still a syntax error (the grammar requires a `'\n'`) but it won't cause an alloc error.

This is only an issue if there's no end-of-line while lexing a rule's cost code (so not a problem with any of lcc's files).