### PR TITLE
Add README blurb regarding C89

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,8 @@ http://storage.webhop.net/documents/interface4.pdf.
 VERSION 4.2 IS INCOMPATIBLE WITH EARLIER VERSIONS OF LCC. DO NOT
 UNLOAD THIS DISTRIBUTION ON TOP OF A 3.X DISTRIBUTION.
 
+LCC is a C89 ("ANSI C") compiler designed to be highly retargetable.
+
 LOG describes the changes since the last release.
 
 CPYRIGHT describes the conditions under you can use, copy, modify, and


### PR DESCRIPTION
Regards #47.

The issue was raised that LCC does not make it obvious that it is a C89 compiler. This occasionally causes problems for developers; for example, the [movfuscator project](https://github.com/xoreaxeaxeax/movfuscator) uses LCC and has to warn its users to not attempt to use C99+ code. To make it clearer to developers, the README should state that LCC works only with C89.

This is not a resolution of the issue; being able to change the input target to C99 would be wonderful. However, it is a necessary change for now.